### PR TITLE
set debian repository based on major version only

### DIFF
--- a/files/repos/Debian-8.0
+++ b/files/repos/Debian-8.0
@@ -1,1 +1,0 @@
-deb https://apt.dockerproject.org/repo debian-jessie main

--- a/tasks/os/Debian.yml
+++ b/tasks/os/Debian.yml
@@ -12,17 +12,16 @@
     id: "{{ docker_gpg_key }}"
     keyserver: "{{ key_server }}"
 
-- name: ensure repo is present
-  copy:
-    src: "repos/{{ ansible_distribution }}-{{ ansible_distribution_version }}"
-    dest: /etc/apt/sources.list.d/docker.list
-  register: repofile
-
-- name: ensure apt cache is updated
-  apt:
-    update_cache: yes
+- name: ensure docker repo is present
+  apt_repository:
+    repo: deb https://apt.dockerproject.org/repo debian-jessie main
+    state: present
+    filename: docker
+    update_cache: true
 
 - name: ensure docker is installed
   apt:
     name: docker-engine
     state: present
+    update_cache: true
+    cache_valid_time: 3600


### PR DESCRIPTION
Debian installation is failing on a current system because it's looking for 'repos/Debian-8.6' and only 'Debian-8.0' is provided.

Since debian repos only reference the major version (ie 'jessie'), using 'ansible_distribution_major_version' for the file name seems appropriate.