### PR TITLE
(resolve conflict in dbichko's fork) set debian repository based on major version only

### DIFF
--- a/files/repos/Debian-8.0
+++ b/files/repos/Debian-8.0
@@ -1,1 +1,0 @@
-deb https://apt.dockerproject.org/repo debian-jessie main

--- a/tasks/os/Debian.yml
+++ b/tasks/os/Debian.yml
@@ -12,13 +12,16 @@
     id: "{{ docker_gpg_key }}"
     keyserver: "{{ key_server }}"
 
-- name: ensure repo is present
-  copy:
-    src: "repos/{{ ansible_distribution }}-{{ ansible_distribution_version }}"
-    dest: /etc/apt/sources.list.d/docker.list
+- name: ensure docker repo is present
+  apt_repository:
+    repo: deb https://apt.dockerproject.org/repo debian-jessie main
+    state: present
+    filename: docker
+    update_cache: true
 
 - name: ensure docker is installed
   apt:
     name: docker-engine
     state: present
-    update_cache: yes
+    update_cache: true
+    cache_valid_time: 3600


### PR DESCRIPTION
I cherry-picked the commit by @dbichko (crediting him as author) and fixed the conflict. I hope this helps move the PR forward.

This is the text from the original commit:

Only update apt-cache when needed

Instead of always updating the apt cache, leverage the 'update_cache'
method during the apt install task.  Prior to this patch, every run of
this role resulted in a "changed" state.  This patch will clean up that
report to only be "changed" when this actually did indeed change (as
updating the apt-cache isn't a meaningful "change").

use apt_repository instead of file copy