### PR TITLE
Support different versions of Docker Engine with official Docker and Rancher setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,11 @@ Default values: (set them in your `docker_config` to overwrite)
     storage-driver: devicemapper
     log-level: info
 
----
-
 ### `docker_version`
 
 Specify the version of Docker to install, e.g. `1.12.6`, `17.05`.
 
 Default value: `17.06`
-
----
 
 ### `setup_script_md5_sum`
 
@@ -37,8 +33,6 @@ Either:
 
 1. Generate an md5 checksum for the desired version's install script
 1. If you know what you are doing and are not worried about security, set this variable to "no" or "false" to disable checksum verification of the setup script.
-
----
 
 ### `setup_script_url`
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,36 @@ Default values: (set them in your `docker_config` to overwrite)
     storage-driver: devicemapper
     log-level: info
 
+---
+
+### `docker_version`
+
+Specify the version of Docker to install, e.g. `1.12.6`, `17.05`.
+
+Default value: `17.06`
+
+---
+
+### `setup_script_md5_sum`
+
+Default value: md5 checksum of default `docker_version` setup script (see `defaults/main.yml` for exact default value)
+
+**If you intend to install a version of Docker other than the default, you must provide an appropriate override value for this variable.**
+
+Either:
+
+1. Generate an md5 checksum for the desired version's install script
+1. If you know what you are doing and are not worried about security, set this variable to "no" or "false" to disable checksum verification of the setup script.
+
+---
+
+### `setup_script_url`
+
+URL pointing to a Docker setup script that will install the specified `docker_version`. 
+
+Default value: `https://releases.rancher.com/install-docker/{{ docker_version }}.sh` 
+
+The default URL utilizes ([Rancher Labs' version-specific, OS-agnostic setup scripts](https://github.com/rancher/install-docker), which in turn just install the appropriate version of `docker-ce` or `docker-engine` from the official Docker `apt` and `yum` repositories.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ URL pointing to a Docker setup script that will install the specified `docker_ve
 
 Default value: `https://releases.rancher.com/install-docker/{{ docker_version }}.sh` 
 
-The default URL utilizes ([Rancher Labs' version-specific, OS-agnostic setup scripts](https://github.com/rancher/install-docker), which in turn just install the appropriate version of `docker-ce` or `docker-engine` from the official Docker `apt` and `yum` repositories.
+The default URL utilizes [Rancher Labs' version-specific, OS-agnostic setup scripts](https://github.com/rancher/install-docker), which in turn just install the appropriate version of `docker-ce` or `docker-engine` from the official Docker `apt` and `yum` repositories.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Default values: (set them in your `docker_config` to overwrite)
 
 Specify the version of Docker to install, e.g. `1.12.6`, `17.05`.
 
-Default value: `17.06`
+Default value: `17.03`
 
 ### `setup_script_md5_sum`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,4 +7,11 @@ default_docker_config:
   storage-driver: devicemapper
   log-level: info
 
-setup_script_url: "https://get.docker.com"
+docker_version: "17.06"
+setup_script_url: "https://releases.rancher.com/install-docker/{{ docker_version }}.sh"
+
+# DANGER! THIS VALUE IS USED TO VERIFY THAT THE DOCKER SETUP SCRIPT IS LEGITIMATE. 
+# DO NOT MODIFY THIS UNLESS YOU HAVE SPECIFIED A DIFFERENT "docker_version" or "setup_script_url"
+# IF YOU HAVE GENERATED AN MD5 CHECKSUM FOR YOUR DESIRED SETUP SCRIPT, STORE IT IN THIS VARIABLE
+# IF YOU REALLY DON'T WANT TO VERIFY CHECKSUM, SET THIS VALUE TO "false" or "no"
+setup_script_md5_sum: "063022bc35d9946215e05b833b53561b" 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ vagrant: no
 default_docker_config:
   storage-driver: devicemapper
   log-level: info
+
+setup_script_url: "https://get.docker.com"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,11 +7,11 @@ default_docker_config:
   storage-driver: devicemapper
   log-level: info
 
-docker_version: "17.06"
+docker_version: "17.03"
 setup_script_url: "https://releases.rancher.com/install-docker/{{ docker_version }}.sh"
 
 # DANGER! THIS VALUE IS USED TO VERIFY THAT THE DOCKER SETUP SCRIPT IS LEGITIMATE. 
 # DO NOT MODIFY THIS UNLESS YOU HAVE SPECIFIED A DIFFERENT "docker_version" or "setup_script_url"
 # IF YOU HAVE GENERATED AN MD5 CHECKSUM FOR YOUR DESIRED SETUP SCRIPT, STORE IT IN THIS VARIABLE
 # IF YOU REALLY DON'T WANT TO VERIFY CHECKSUM, SET THIS VALUE TO "false" or "no"
-setup_script_md5_sum: "063022bc35d9946215e05b833b53561b" 
+setup_script_md5_sum: "2905656d3510d739dfd427713f6d421b" 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   - name: Ubuntu
     versions:
       - xenial
-      - zesty
+      #- zesty
   galaxy_tags:
     - docker
     - swarm

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,15 @@
+---
+
+- name: If docker_version is defined, switch to rancher setup script
+  set_fact: 
+    setup_script_url: "https://releases.rancher.com/install-docker/{{ docker_version }}.sh"
+  when: docker_version is defined
+
+- name: Download docker setup script for desired version
+  get_url:
+    url: "{{ setup_script_url }}"
+    dest: "/tmp/docker-setup.sh"
+    mode: 0755
+
+- name: Execute docker setup script
+  shell: "/tmp/docker-setup.sh"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,14 +1,14 @@
 ---
 
-- name: If docker_version is defined, switch to rancher setup script
-  set_fact: 
-    setup_script_url: "https://releases.rancher.com/install-docker/{{ docker_version }}.sh"
-  when: docker_version is defined
+- set_fact:
+    setup_script_checksum: "md5:{{ setup_script_md5_sum }}"
+  when: setup_script_md5_sum is defined and setup_script_md5_sum
 
 - name: Download docker setup script for desired version
   get_url:
     url: "{{ setup_script_url }}"
     dest: "/tmp/docker-setup.sh"
+    checksum: "{{ setup_script_checksum|default(omit) }}"
     mode: 0755
 
 - name: Execute docker setup script

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,8 @@
 
 - include: "os/{{ ansible_os_family }}.yml"
 
+- include: "install.yml"
+
 - name: ensure config folder is present
   file:
     path: /etc/docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: Construct docker-engine version spec
+  set_fact:
+    docker_engine_pkg: "{{ ( docker_version is defined ) | ternary('docker-engine=' ~ docker_version, 'docker-engine') }}"
+
 - include: "os/{{ ansible_os_family }}.yml"
 
 - name: ensure config folder is present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
 
-- name: Construct docker-engine version spec
-  set_fact:
-    docker_engine_pkg: "{{ ( docker_version is defined ) | ternary('docker-engine=' ~ docker_version, 'docker-engine') }}"
-
 - include: "os/{{ ansible_os_family }}.yml"
 
 - name: ensure config folder is present

--- a/tasks/os/Debian.yml
+++ b/tasks/os/Debian.yml
@@ -7,21 +7,18 @@
     - apt-transport-https
     - ca-certificates
 
-- name: ensure Docker GPG key is present
-  apt_key:
-    id: "{{ docker_gpg_key }}"
-    keyserver: "{{ key_server }}"
+- name: If docker_version is defined, switch to rancher setup script
+  set_fact: 
+    setup_script_url: "https://releases.rancher.com/install-docker/{{ docker_version }}.sh"
+  when: docker_version is defined
 
-- name: ensure docker repo is present
-  apt_repository:
-    repo: deb https://apt.dockerproject.org/repo debian-jessie main
-    state: present
-    filename: docker
-    update_cache: true
+- name: Download docker setup script for desired version
+  get_url:
+    url: "{{ setup_script_url }}"
+    dest: "/tmp/docker-setup.sh"
+    mode: 0755
 
-- name: ensure docker is installed
-  apt:
-    name: "{{ docker_engine_pkg }}"
-    state: present
-    update_cache: true
-    cache_valid_time: 3600
+- name: Execute docker setup script
+  shell: "docker-setup.sh"
+  args:
+    chdir: /tmp/

--- a/tasks/os/Debian.yml
+++ b/tasks/os/Debian.yml
@@ -6,17 +6,3 @@
   with_items:
     - apt-transport-https
     - ca-certificates
-
-- name: If docker_version is defined, switch to rancher setup script
-  set_fact: 
-    setup_script_url: "https://releases.rancher.com/install-docker/{{ docker_version }}.sh"
-  when: docker_version is defined
-
-- name: Download docker setup script for desired version
-  get_url:
-    url: "{{ setup_script_url }}"
-    dest: "/tmp/docker-setup.sh"
-    mode: 0755
-
-- name: Execute docker setup script
-  shell: "/tmp/docker-setup.sh"

--- a/tasks/os/Debian.yml
+++ b/tasks/os/Debian.yml
@@ -19,6 +19,4 @@
     mode: 0755
 
 - name: Execute docker setup script
-  shell: "docker-setup.sh"
-  args:
-    chdir: /tmp/
+  shell: "/tmp/docker-setup.sh"

--- a/tasks/os/Debian.yml
+++ b/tasks/os/Debian.yml
@@ -21,7 +21,7 @@
 
 - name: ensure docker is installed
   apt:
-    name: docker-engine
+    name: "{{ docker_engine_pkg }}"
     state: present
     update_cache: true
     cache_valid_time: 3600

--- a/tasks/os/RedHat.yml
+++ b/tasks/os/RedHat.yml
@@ -6,5 +6,5 @@
 
 - name: ensure docker is installed
   yum:
-    name: docker-engine
+    name: "{{ docker_engine_pkg }}"
     state: present

--- a/tasks/os/RedHat.yml
+++ b/tasks/os/RedHat.yml
@@ -1,10 +1,8 @@
 ---
-- name: ensure repo is present
-  copy:
-    src: repos/Centos-7
-    dest: /etc/yum.repos.d/docker.repo
 
-- name: ensure docker is installed
+- name: ensure docker dependencies are installed
   yum:
-    name: "{{ docker_engine_pkg }}"
+    name: "{{ item }}"
     state: present
+  with_items:
+    - ca-certificates


### PR DESCRIPTION
The current release of the role uses apt and yum packages for installation, which tend to be several releases behind stable.

Docker provides a standard OS-agnostic setup script for the latest version of Docker at https//get.docker.com, which this PR implements fetching and running

To install a specific version of Docker, Rancher Labs provide a set of equivalent OS-agnostic setup scripts by version, which will be used if the new optional variable `docker_version` is provided to the role.

Could add checksum verification if security is a concern