### PR TITLE
Allow modifying the docker daemon launch arguments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ vagrant: no
 default_docker_config:
   storage-driver: devicemapper
   log-level: info
+# for legacy version of docker this should be "/usr/bin/docker daemon"
+docker_daemon_cmd: /usr/bin/dockerd

--- a/templates/docker.j2.service
+++ b/templates/docker.j2.service
@@ -8,7 +8,7 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/docker daemon -H unix:///var/run/docker.sock
+ExecStart={{ docker_daemon_cmd }} {{ docker_daemon_additional_args }} -H unix:///var/run/docker.sock
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
Not all of the arguments are properly supported at present in the json
file.  Notably `--cluster-store-opt kv.certfile=foo.pem`  etc.

This allows users to specify these as arguments.