### PR TITLE
Add yum-utils as dependency

### DIFF
--- a/tasks/os/RedHat.yml
+++ b/tasks/os/RedHat.yml
@@ -6,3 +6,4 @@
     state: present
   with_items:
     - ca-certificates
+    - yum-utils


### PR DESCRIPTION
Cause during installation it's using yum-config-manager, and if it's not
installed it fails with:
yum-config-manager: command not found

Change-Id: I68868e97c7e3b4fb99e286652b9864539afba264