### PR TITLE
Limit reloading the systemctl daemon to distributions using systemd

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,8 @@
 - name: reload unit
   become: true
   command: systemctl daemon-reload
+  when:
+    - ansible_service_mgr == "systemd"
 
 - name: restart docker
   service:


### PR DESCRIPTION
This is actually the work of StudioEtrange in a separate fork that has not been merged back in to this one. This is commit 2e01f70 on that fork.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongrelion/ansible-role-docker/21)
<!-- Reviewable:end -->
