### PR TITLE
Using dockerd as docker daemon has been deprecated

### DIFF
--- a/templates/docker.j2.service
+++ b/templates/docker.j2.service
@@ -8,7 +8,7 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/docker daemon -H unix:///var/run/docker.sock
+ExecStart=/usr/bin/dockerd -H unix:///var/run/docker.sock
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
Fix for #22 