### PR TITLE
Ansible include module is deprecated in Ansible 2.4 and must be repla…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,11 @@
   tags:
     - always
 
-- include: preflight.yml
+- include_tasks: preflight.yml
 
-- include: install.yml
+- include_tasks: install.yml
 
-- include: configure.yml
+- include_tasks: configure.yml
 
 - name: ensure starts on system boot
   systemd:


### PR DESCRIPTION
Ansible `include` module is deprecated in Ansible 2.4 and must be replaced with either `import_tasks` for static inclusions or `include_tasks` for dynamic inclusions. As such roles/tasks/main.yml has been updated with `include_tasks`. Please test on previous version to Ansible 2.4 before merging.