### PR TITLE
Change location of systemd service file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,13 +57,13 @@
 
 - name: ensure unit file folder is present
   file:
-    path: /usr/lib/systemd/system
+    path: /etc/systemd/system
     state: directory
 
 - name: ensure unit file is present & up to date
   template:
     src: docker.j2.service
-    dest: /usr/lib/systemd/system/docker.service
+    dest: /etc/systemd/system/docker.service
   notify:
     - restart docker
 


### PR DESCRIPTION
According to [systemd docs](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Unit%20File%20Load%20Path) and ways of packaging applications you shouldn't overwrite systemd service file in /usr/lib/systemd/system/ since this file **will** be overwritten by package installer on update. Safe place for storing service files is in /etc/systemd/system and this PR fixes this.