### PR TITLE
Remove installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,42 +17,9 @@ Default values: (set them in your `docker_config` to overwrite)
 
 ### `docker_version`
 
-Specify the version of Docker to install, e.g. `1.12.6`, `17.05`.
+Specify the version of Docker to install, e.g. `1.12.6`, `17.05`. It allows to upgrade to latest version by specifying `latest`.
 
-Default value: `17.03`
-
-### `docker_setup_script_md5_sum`
-
-Default value: md5 checksum of default `docker_version` setup script (see `defaults/main.yml` for exact default value)
-
-**If you intend to install a version of Docker other than the default, you must provide an appropriate override value for this variable.**
-
-Either:
-
-1. Generate an md5 checksum for the desired version's install script
-1. If you know what you are doing and are not worried about security, set this variable to "no" or "false" to disable checksum verification of the setup script.
-
-### `docker_setup_script_url`
-
-URL pointing to a Docker setup script that will install the specified `docker_version`.
-
-Default value: `https://releases.rancher.com/install-docker/{{ docker_version }}.sh`
-
-The default URL utilizes [Rancher Labs' version-specific, OS-agnostic setup scripts](https://github.com/rancher/install-docker), which in turn just install the appropriate version of `docker-ce` or `docker-engine` from the official Docker `apt` and `yum` repositories.
-
-### `docker_upgrade`
-
-Per default, this role will only download and run the installation script when
-Docker is not installed (or more precise: when `dockerd` is not in `$PATH`). Set
-`docker_upgrade` to `True` to override this behavior and force the install
-script to be run.
-
-So in order to upgrade Docker on managed systems, take the following steps:
-
-0. Either download a newer version of this role (with a more recent default
-   version) or update `docker_version` and `docker_setup_script_md5_sum` in your
-   host/group vars.
-1. Run your playbook with `-e docker_upgrade=True`
+Default value: `17.06`
 
 ### `docker_proxy`, `docker_http_proxy`, `docker_https_proxy`, `docker_no_proxy`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ docker_no_proxy: ""
 
 docker_version: "17.06"
 #docker_version: "latest"
-docker_upgrade: false
+#docker_upgrade: false
 
 docker_default_config:
   storage-driver: devicemapper

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,19 +1,15 @@
 ---
 dockerpy: no
+
 docker_proxy: no
 docker_http_proxy: ""
 docker_https_proxy: ""
 docker_no_proxy: ""
+
+docker_version: "17.06"
+#docker_version: "latest"
 docker_upgrade: false
+
 docker_default_config:
   storage-driver: devicemapper
   log-level: info
-
-docker_version: "17.06"
-docker_setup_script_url: "https://releases.rancher.com/install-docker/{{ docker_version }}.sh"
-
-# DANGER! THIS VALUE IS USED TO VERIFY THAT THE DOCKER SETUP SCRIPT IS LEGITIMATE.
-# DO NOT MODIFY THIS UNLESS YOU HAVE SPECIFIED A DIFFERENT "docker_version" or "setup_script_url"
-# IF YOU HAVE GENERATED AN MD5 CHECKSUM FOR YOUR DESIRED SETUP SCRIPT, STORE IT IN THIS VARIABLE
-# IF YOU REALLY DON'T WANT TO VERIFY CHECKSUM, SET THIS VALUE TO "false" or "no"
-docker_setup_script_md5_sum: "6be324016277879d49bd0e7f9f91e546"

--- a/files/repos/Centos-7
+++ b/files/repos/Centos-7
@@ -1,6 +1,0 @@
-[dockerrepo]
-name=Docker Repository
-baseurl=https://yum.dockerproject.org/repo/main/centos/7/
-enabled=1
-gpgcheck=1
-gpgkey=https://yum.dockerproject.org/gpg

--- a/files/repos/Ubuntu-16.04
+++ b/files/repos/Ubuntu-16.04
@@ -1,1 +1,0 @@
-deb https://apt.dockerproject.org/repo ubuntu-xenial main

--- a/files/repos/Ubuntu-17.04
+++ b/files/repos/Ubuntu-17.04
@@ -1,1 +1,0 @@
-deb https://apt.dockerproject.org/repo ubuntu-zesty main

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,7 +8,7 @@
     - /etc/systemd/system
 
 - name: ensure daemon config file is present
-  template:
+  copy:
     content: |
       {{ docker_json | to_nice_json(indent=2) }}
     dest: /etc/docker/daemon.json
@@ -21,9 +21,8 @@
   when: docker_proxy
 
 - name: create http-proxy.conf
-  template:
+  copy:
     content: |
-      # {{ ansible_managed }}
       [Service]
       Environment="HTTP_PROXY={{ docker_http_proxy }}" "HTTPS_PROXY={{ docker_https_proxy }}" "NO_PROXY={{ docker_no_proxy }}"
     dest: /etc/systemd/system/docker.service.d/http-proxy.conf

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -34,5 +34,3 @@
     src: docker.j2.service
     dest: /etc/systemd/system/docker.service
   notify: restart docker
-
-

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,39 @@
+---
+- name: ensure needed directories are present
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - /etc/docker
+    - /etc/systemd/system
+
+- name: ensure daemon config file is present
+  template:
+    content: |
+      {{ docker_json | to_nice_json(indent=2) }}
+    dest: /etc/docker/daemon.json
+  notify: restart docker
+
+- name: create directory for proxy file
+  file:
+    path: /etc/systemd/system/docker.service.d
+    state: directory
+  when: docker_proxy
+
+- name: create http-proxy.conf
+  template:
+    content: |
+      # {{ ansible_managed }}
+      [Service]
+      Environment="HTTP_PROXY={{ docker_http_proxy }}" "HTTPS_PROXY={{ docker_https_proxy }}" "NO_PROXY={{ docker_no_proxy }}"
+    dest: /etc/systemd/system/docker.service.d/http-proxy.conf
+  notify: restart docker
+  when: docker_proxy
+
+- name: ensure unit file is present & up to date
+  template:
+    src: docker.j2.service
+    dest: /etc/systemd/system/docker.service
+  notify: restart docker
+
+

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,17 +19,18 @@
     - docker.io
 
 - block:
-  - name: download GPG key
-    get_url:
-      url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
-      dest: "/tmp/docker_{{ ansible_distribution | lower }}.gpg"
-    become: no
-    run_once: true
-    delegate_to: localhost
+#  - name: download GPG key
+#    get_url:
+#      url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+#      dest: "/tmp/docker_{{ ansible_distribution | lower }}.gpg"
+#    become: no
+#    run_once: true
+#    delegate_to: localhost
 
   - name: add GPG key
     apt_key:
-      data: "{{ lookup('file', '/tmp/docker_{{ ansible_distribution | lower }}.gpg') }}"
+      #data: "{{ lookup('file', '/tmp/docker_{{ ansible_distribution | lower }}.gpg') }}"
+      url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
       state: present
 
   - name: add docker repository | Debian

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install system dependencies
+- name: install system dependencies
   package:
     name: "{{ item }}"
     state: present
@@ -8,13 +8,44 @@
   until: _dependencies_install | success
   with_items: "{{ docker_dependencies }}"
 
-- name: Remove old versions
+- name: remove old versions
   package:
     name: "{{ item }}"
     state: absent
   with_items:
     - lxc-docker
     - docker-engine
+    - docker
+    - docker.io
+
+- block:
+  - name: download GPG key
+    get_url:
+      url: "https://download.docker.com/linux/ubuntu/gpg"
+      dest: "/tmp/docker.gpg"
+    become: no
+    run_once: true
+    delegate_to: localhost
+
+  - name: add GPG key
+    apt_key:
+      data: "{{ lookup('file', '/tmp/docker.gpg') }}"
+      state: present
+
+  - name: add docker repository | Debian
+    apt_repository:
+      repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+      state: present
+  when: ansible_os_family == "Debian"
+
+- name: add docker repository | RedHat
+  yum_repository:
+    name: docker-ce-stable
+    description: "Docker CE Stable - $basearch"
+    baseurl: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/$releasever/$basearch/stable"
+    gpgcheck: true
+    gpgkey: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+  when: ansible_os_family == "RedHat" and ansible_distribution != "OracleLinux"
 
 - name: Install docker
   package:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,17 +1,36 @@
 ---
-- name: Compose md5 checksum
-  set_fact:
-    __docker_setup_script_checksum: "md5:{{ docker_setup_script_md5_sum }}"
-  when: docker_setup_script_md5_sum != ""
+- name: Install system dependencies
+  package:
+    name: "{{ item }}"
+    state: present
+  register: _dependencies_install
+  retries: 2
+  until: _dependencies_install | success
+  with_items: "{{ docker_dependencies }}"
 
-- name: Download docker setup script for desired version
-  get_url:
-    url: "{{ docker_setup_script_url }}"
-    dest: "/tmp/docker-setup.sh"
-    checksum: "{{ __docker_setup_script_checksum|default(omit) }}"
-    mode: 0755
+- name: Remove old versions
+  package:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - lxc-docker
+    - docker-engine
 
-- name: Execute docker setup script
-  shell: "/tmp/docker-setup.sh"
-  tags:
-    - skip_ansible_lint
+- name: Install docker
+  package:
+    name: "{{ docker_package | default('docker-ce') }}"
+    state: present
+    update_cache: yes
+  register: __ret
+  retries: 10
+  until: __ret is succeeded
+  notify:
+    - restart docker
+
+- name: ensure docker-py module is installed
+  pip:
+    name: docker-py
+    version: 1.9.0
+  when: dockerpy
+
+

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,9 +3,9 @@
   package:
     name: "{{ item }}"
     state: present
-  register: _dependencies_install
-  retries: 2
-  until: _dependencies_install | success
+  register: __ret
+  retries: 5
+  until: __ret is succeeded
   with_items: "{{ docker_dependencies }}"
 
 - name: remove old versions
@@ -19,17 +19,8 @@
     - docker.io
 
 - block:
-#  - name: download GPG key
-#    get_url:
-#      url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
-#      dest: "/tmp/docker_{{ ansible_distribution | lower }}.gpg"
-#    become: no
-#    run_once: true
-#    delegate_to: localhost
-
   - name: add GPG key
     apt_key:
-      #data: "{{ lookup('file', '/tmp/docker_{{ ansible_distribution | lower }}.gpg') }}"
       url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
       state: present
 
@@ -64,5 +55,3 @@
     name: docker-py
     version: 1.9.0
   when: dockerpy
-
-

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,20 +21,20 @@
 - block:
   - name: download GPG key
     get_url:
-      url: "https://download.docker.com/linux/ubuntu/gpg"
-      dest: "/tmp/docker.gpg"
+      url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+      dest: "/tmp/docker_{{ ansible_distribution | lower }}.gpg"
     become: no
     run_once: true
     delegate_to: localhost
 
   - name: add GPG key
     apt_key:
-      data: "{{ lookup('file', '/tmp/docker.gpg') }}"
+      data: "{{ lookup('file', '/tmp/docker_{{ ansible_distribution | lower }}.gpg') }}"
       state: present
 
   - name: add docker repository | Debian
     apt_repository:
-      repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+      repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
       state: present
   when: ansible_os_family == "Debian"
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,8 +18,8 @@
 
 - name: Install docker
   package:
-    name: "{{ docker_package | default('docker-ce') }}"
-    state: present
+    name: "{{ docker_package }}"
+    state: "{{ (docker_version == 'latest') | ternary('latest', 'present') }}"
     update_cache: yes
   register: __ret
   retries: 10

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,65 +7,9 @@
 
 - include: preflight.yml
 
-- name: ensure docker dependencies are installed
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ docker_dependencies }}"
+- include: install.yml
 
-- name: check if docker is installed
-  command: which dockerd
-  register: which_dockerd
-  changed_when: False
-  ignore_errors: yes
-
-- include: "install.yml"
-  when: docker_upgrade or (which_dockerd | failed)
-
-- name: ensure config folder is present
-  file:
-    path: /etc/docker
-    state: directory
-
-- name: ensure docker-py module is installed
-  pip:
-    name: docker-py
-    version: 1.9.0
-  when: dockerpy
-
-- name: create directory for proxy file
-  file:
-    path: /etc/systemd/system/docker.service.d
-    state: directory
-  when: docker_proxy
-
-- name: create http-proxy.conf
-  template:
-    src: http-proxy.j2.conf
-    dest: /etc/systemd/system/docker.service.d/http-proxy.conf
-  notify:
-    - reload unit
-    - restart docker
-  when: docker_proxy
-
-- name: ensure daemon config file is present
-  template:
-    src: daemon.j2.json
-    dest: /etc/docker/daemon.json
-  notify:
-    - restart docker
-
-- name: ensure unit file folder is present
-  file:
-    path: /etc/systemd/system
-    state: directory
-
-- name: ensure unit file is present & up to date
-  template:
-    src: docker.j2.service
-    dest: /etc/systemd/system/docker.service
-  notify:
-    - restart docker
+- include: configure.yml
 
 - name: ensure starts on system boot
   systemd:

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,29 +1,14 @@
 ---
 - name: Set backwards compatibility for docker_upgrade var
   set_fact:
-    docker_upgrade: "{{ upgrade_docker }}"
-  when: upgrade_docker is defined
+    docker_version: latest
+  when: upgrade_docker is defined or docker_upgrade is defined
 
 - name: Set backwards compatibility for default_config
   set_fact:
     docker_default_config: "{{ default_docker_config }}"
   when: default_docker_config is defined
 
-- name: Set backwards compatibility for setup_script_md5_sum
-  set_fact:
-    docker_setup_script_md5_sum: "{{ setup_script_md5_sum }}"
-  when: setup_script_md5_sum is defined
-
-- name: Set backwards compatibility for setup_script_url
-  set_fact:
-    docker_setup_script_url: "{{ setup_script_url }}"
-  when: setup_script_url is defined
-
 - name: apply default daemon config
   set_fact:
     docker_json: "{{ docker_default_config | combine(docker_config | default({})) }}"
-
-- name: update docker (backwards compatibility flag)
-  set_fact:
-    docker_version: latest
-  when: docker_upgrade

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -22,3 +22,8 @@
 - name: apply default daemon config
   set_fact:
     docker_json: "{{ docker_default_config | combine(docker_config | default({})) }}"
+
+- name: update docker (backwards compatibility flag)
+  set_fact:
+    docker_version: latest
+  when: docker_upgrade

--- a/templates/daemon.j2.json
+++ b/templates/daemon.j2.json
@@ -1,1 +1,0 @@
-{{ docker_json | to_nice_json(indent=2) }}

--- a/templates/http-proxy.j2.conf
+++ b/templates/http-proxy.j2.conf
@@ -1,2 +1,0 @@
-[Service]
-Environment="HTTP_PROXY={{ docker_http_proxy }}" "HTTPS_PROXY={{ docker_https_proxy }}" "NO_PROXY={{ docker_no_proxy }}"

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -4,6 +4,7 @@
   roles:
     - ansible-role-docker
   vars:
+    docker_version: latest
     default_docker_config:
       storage-driver: vfs
       log-level: info

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -46,9 +46,4 @@ def test_service(host):
 
 
 def test_packages(host):
-    if host.system_info.distribution == 'ol':
-        DOCKER = 'docker-engine'
-    else:
-        DOCKER = 'docker-ce'
-
-    assert host.package(DOCKER).is_installed
+    assert host.package('docker-ce').is_installed

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,3 +1,4 @@
+docker_package: "docker-ce{{ (docker_version != 'latest') | ternary('=' ~ docker_version, '') }}"
 docker_dependencies:
   - apt-transport-https
   - ca-certificates

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,3 +1,5 @@
 docker_dependencies:
   - apt-transport-https
   - ca-certificates
+  - software-properties-common
+  - python-pip

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,3 +1,4 @@
+grafana_package: "docker-ce{{ (docker_version != 'latest') | ternary('-' ~ docker_version, '') }}"
 docker_dependencies:
   - ca-certificates
   - yum-utils

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,3 +1,6 @@
 docker_dependencies:
   - ca-certificates
   - yum-utils
+  - epel-release
+  - e2fsprogs
+  - python2-pip


### PR DESCRIPTION
Replacing installation script with ansible tasks along with some more cleanup.

Installation method based on previous script and official docs (https://docs.docker.com/install)

Added:
- easier upgrade method (just specify `latest` as `docker_version`)
- testing on `latest` version
- `tasks/configure.yml` file for cleaner look

Removed:
- installation script and everything connected with it
- unused files
- some simple templates
- `docker_upgrade` and `upgrade_docker` variables. Backwards compatibility is maintained by setting `docker_version: latest` when any one of those two vars is detected (not checking value)

Resolves #31 