### PR TITLE
ansible 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ cache: pip
 services:
   - docker
 env:
-  - ANSIBLE='ansible>=2.2.0,<2.3.0'
   - ANSIBLE='ansible>=2.3.0,<2.4.0'
   - ANSIBLE='ansible>=2.4.0,<2.5.0'
+  - ANSIBLE='ansible>=2.5.0,<2.6.0'
 install:
   - pip install ${ANSIBLE} 'ansible-lint>=3.4.15' 'molecule==1.25.0' docker git-semver 'testinfra>=1.7.0,<=1.10.1'
 before_script:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Docker
   company: Container Solutions
   license: MIT
-  min_ansible_version: 2.1
+  min_ansible_version: 2.3
   platforms:
   - name: EL
     versions:


### PR DESCRIPTION
This removes tests on ansible 2.2.x and adds testing on ansible 2.5.x

Changed meta information to reflect minimal supported (tested) ansible version.