### PR TITLE
better docker_version support

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,5 +1,5 @@
 ---
-docker_package: "docker-ce{{ (docker_version != 'latest') | ternary('=' ~ docker_version, '') }}"
+docker_package: "docker-ce{{ (docker_version != 'latest') | ternary('=' ~ docker_version ~ '*', '') }}"
 docker_dependencies:
   - apt-transport-https
   - ca-certificates

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,5 +1,5 @@
 ---
-docker_package: "docker-ce{{ (docker_version != 'latest') | ternary('-' ~ docker_version, '') }}"
+docker_package: "docker-ce{{ (docker_version != 'latest') | ternary('-' ~ docker_version ~ '*', '') }}"
 docker_dependencies:
   - ca-certificates
   - yum-utils


### PR DESCRIPTION
Add wildcard at the end when creating `docker_package` from `docker_version` so we can have:
```yaml
docker_version: 17.06
```
instead of
```yaml
docker_version: 17.06.0~ce-0~ubuntu
```

Resolves #46 