### PR TITLE
Add docker-common package to be removed before installation

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,6 +16,7 @@
     - lxc-docker
     - docker-engine
     - docker
+    - docker-common
     - docker.io
 
 - block:


### PR DESCRIPTION
Fixes issue on CentOS systems, with docker-ce-18.03.1

```
Transaction check error:
  file /usr/bin/docker from install of docker-ce-18.03.1.ce-1.el7.centos.x86_64 conflicts with file from package docker-common-2:1.13.1-53.git774336d.el7.centos.x86_64
  file /usr/bin/docker-containerd from install of docker-ce-18.03.1.ce-1.el7.centos.x86_64 conflicts with file from package docker-common-2:1.13.1-53.git774336d.el7.centos.x86_64
  file /usr/bin/docker-containerd-shim from install of docker-ce-18.03.1.ce-1.el7.centos.x86_64 conflicts with file from package docker-common-2:1.13.1-53.git774336d.el7.centos.x86_64
  file /usr/bin/dockerd from install of docker-ce-18.03.1.ce-1.el7.centos.x86_64 conflicts with file from package docker-common-2:1.13.1-53.git774336d.el7.centos.x86_64
```

Signed-off-by: Lukas Bednar <lbednar@redhat.com>