### PR TITLE
Fix __pycache__ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /.vagrant/
 
 # Ignore molecule and pytest files
-**__pycache__**
+__pycache__/
 .molecule
 .pytest_cache
 


### PR DESCRIPTION
Used syntax was invalid
`pycache` would also have work but would have match both directories and files.
The trailing slash target only directories.

As visible at git-scm.com/docs/gitignore double asterisks without slashes to target directories are invalid.

To be more specific, it looks like git is somehow accepting it, but that it doesn't respect specs, and therefore break other tools like ripgrep for example, which is following specs.

See BurntSushi/ripgrep#373 for example