### PR TITLE
use tox, ansible 2.6, and allow using remote docker host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__/
 .molecule
 .pytest_cache
+.tox
 
 # Ignore retry files
 *.retry

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ cache: pip
 services:
   - docker
 env:
-  - ANSIBLE='ansible>=2.3.0,<2.4.0'
-  - ANSIBLE='ansible>=2.4.0,<2.5.0'
-  - ANSIBLE='ansible>=2.5.0,<2.6.0'
+  - ANSIBLE=2.4
+  - ANSIBLE=2.5
+  - ANSIBLE=2.6
 install:
-  - pip install ${ANSIBLE} 'ansible-lint>=3.4.15' 'molecule>=2.12.0' docker git-semver 'testinfra>=1.7.0'
+  - pip install tox-travis git-semver
 script:
-  - molecule test --all
+  - tox
 deploy:
   provider: script
   skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install and configure [docker](https://www.docker.com) containerization platform
 
 ## Requirements
 
-- Ansible >= 2.3
+- Ansible >= 2.4
 
 ## Role Variables
 
@@ -52,17 +52,22 @@ Install and configure docker daemon
 
 ## Local Testing
 
-The preferred way of locally testing the role is to use Docker and [molecule](https://github.com/metacloud/molecule) (v2.x). You will have to install Docker on your system. See Get started for a Docker package suitable to for your system.
-All packages you need to can be specified in one line:
+The preferred way of locally testing the role is to use Docker and [molecule](https://github.com/metacloud/molecule) (v2.x). You will have to install Docker on your system. See "Get started" for a Docker package suitable to for your system.
+We are using tox to simplify process of testing on multiple ansible versions. To install tox execute:
 ```sh
-pip install ansible 'ansible-lint>=3.4.15' 'molecule>2.12.0' docker 'testinfra>=1.7.0'
+pip install tox
 ```
-This should be similar to one listed in `.travis.yml` file in `install` section.
-After installing test suit you can run test by running
+To run tests on all ansible versions (WARNING: this can take some time)
 ```sh
-molecule test
+tox
 ```
-For more information about molecule go to their [docs](https://molecule.readthedocs.io/en/latest/).
+To run a custom molecule command on custom environment with only default test scenario:
+```sh
+tox -e py27-ansible25 -- molecule test -s default
+```
+For more information about molecule go to their [docs](http://molecule.readthedocs.io/en/latest/).
+
+If you would like to run tests on remote docker host just specify `DOCKER_HOST` variable before running tox tests.
 
 ## License
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Docker
   company: Container Solutions
   license: MIT
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
   - name: EL
     versions:

--- a/molecule/alternative/molecule.yml
+++ b/molecule/alternative/molecule.yml
@@ -8,16 +8,19 @@ lint:
 platforms:
   - name: xenial
     image: paulfantom/ubuntu-molecule:16.04
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: jessie
     image: paulfantom/debian-molecule:8
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: centos7
     image: paulfantom/centos-molecule:7
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,16 +8,19 @@ lint:
 platforms:
   - name: xenial
     image: paulfantom/ubuntu-molecule:16.04
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: jessie
     image: paulfantom/debian-molecule:8
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: centos7
     image: paulfantom/centos-molecule:7
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,5 @@
+molecule>=2.15.0
+docker
+ansible-lint>=3.4.0
+testinfra>=1.7.0
+jmespath

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+minversion = 1.8
+envlist = py{27}-ansible{24,25,26}
+skipsdist = true
+
+[travis:env]
+ANSIBLE=
+  2.4: ansible24
+  2.5: ansible25
+  2.6: ansible26
+
+[testenv]
+passenv = *
+deps =
+    -rtest-requirements.txt
+    ansible24: ansible<2.5
+    ansible25: ansible<2.6
+    ansible26: ansible<2.7
+commands =
+    {posargs:molecule test --all --destroy always}


### PR DESCRIPTION
[minor] changes

- simplify using test suite with tox
- add tests on ansible 2.6
- deprecate ansible 2.3
- add option to run tests on remote docker host by using `DOCKER_HOST` variable

This should also allow to proceed with #26