### PR TITLE
Use role_name in metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,6 +2,7 @@ galaxy_info:
   author: Carlos León
   description: Docker
   company: Container Solutions
+  role_name: docker
   license: MIT
   min_ansible_version: 2.4
   platforms:


### PR DESCRIPTION
Use undocumented feature of ansible galaxy to ensure correct role name.