### PR TITLE
Install iptables as a dependency on redhat systems

### DIFF
--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -7,3 +7,4 @@ docker_dependencies:
   - yum-utils
   - epel-release
   - e2fsprogs
+  - iptables


### PR DESCRIPTION
The docker daemon will fail to start without it.

Signed-off-by: Lukas Bednar <lbednar@redhat.com>